### PR TITLE
Add Docker support, set hardcoded values to ENV variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:bullseye-slim
+
+RUN apt-get update && apt-get -y install supervisor nginx python3-pip procps
+
+COPY netbox_prometheus.py /netbox_prometheus.py
+COPY requirements.txt /requirements.txt
+
+ADD conf/default.conf /etc/nginx/sites-enabled/default
+ADD poll.sh /
+
+COPY conf/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+RUN pip3 install -r /requirements.txt \
+	&& chmod +x /netbox_prometheus.py \
+	&& mkdir -p /etc/prometheus/targets.d /var/www/html/metrics \
+	&& chmod +x /poll.sh
+
+EXPOSE 80
+CMD ["/usr/bin/supervisord"]

--- a/README.md
+++ b/README.md
@@ -287,3 +287,25 @@ SITE_TAG = "prometheus2"
 Then in Netbox, tag sites A, B and C with "prometheus1", and sites A, D and
 E with "prometheus2".  The correct targets will be generated for each
 prometheus instance.
+
+# Docker Support
+
+If run Prometheus in Docker or have Docker running locally. The `Dockerfile`  included should make it quicker to get started.
+
+## Building the image
+```
+docker build -t netbox-promethus .
+```
+
+## Running the container
+```
+docker run -d -p 80:80 --name netbox-promethus -e NETBOX_URL="https://netbox.example.net" -e API_TOKEN="XXXXXXXX"
+```
+
+## Overriding the poll interval
+
+`Poll.sh` contains an `ENV` var `SLEEP_INT` to override the default poll interval of `300` seconds. This is optional, here we are setting it to poll every minute. The default value is `300` seconds.
+
+```
+docker run -d -p 80:80 --name netbox-promethus -e NETBOX_URL="https://netbox.example.net" -e API_TOKEN="XXXXXXXX" -e SLEEP_INT=60 netbox-promethus
+```

--- a/conf/default.conf
+++ b/conf/default.conf
@@ -1,0 +1,10 @@
+# Default Nginx endpoint to expose metrics
+server {
+  server_name _;
+  listen *:80 default_server deferred;
+  location / {
+	  add_header Content-Type text/plain;
+	  root /var/www/html;
+  }
+
+}

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -1,0 +1,21 @@
+[supervisord]
+nodaemon=true
+ 
+[program:nginx]
+command=/usr/sbin/nginx -g "daemon off;"
+priority=900
+stdout_logfile= /dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+username=www-data
+autorestart=true
+
+[program:netbox_prometheus]
+directory=/
+command=/poll.sh
+stdout_logfile= /dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+autostart=true

--- a/netbox_prometheus.py
+++ b/netbox_prometheus.py
@@ -124,8 +124,8 @@ class ConfigBuilder:
         self.replace_file(filename, content)
 
 if __name__ == "__main__":
-    API_URL = "https://netbox.example.net"
-    API_TOKEN = "XXXXXXXX"
+    API_URL = os.getenv('NETBOX_URL', "https://netbox.example.net")
+    API_TOKEN = os.getenv('API_TOKEN', "XXXXXXXX")
     SITE_TAG = "prometheus"  # we will poll devices in all sites with this tag
     DIR = "/etc/prometheus/targets.d"
     METRICS = "/var/www/html/metrics/netbox"
@@ -134,6 +134,9 @@ if __name__ == "__main__":
     #METRICS = "/tmp/netbox.prom"
 
     nb = pynetbox.api(API_URL, token=API_TOKEN)
+    # Wether or not to validate the TLS certificate of API_URL
+    nb.http_session.verify = True
+
     builder = ConfigBuilder(
         nb=nb,
         filter={

--- a/poll.sh
+++ b/poll.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+# Sleep interval for how often to poll (300s) This can be controlled by setting SLEEP_INT env var.
+sleep_duration="${SLEEP_INT:-300}"
+
+while true; do (python3 netbox_prometheus.py; sleep $sleep_duration); done
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pynetbox
+pyyaml


### PR DESCRIPTION
Hello, We decided to poke at your script so I made some updates. Specifically:

- Setup a Docker build with making the least amount of changes to the original script.
- Made API_URL + API_TOKEN env vars but set them to the defaults if not set. 
- I also added nb.http_session.verify = True which should help those of us who had issues with validating the API_URL certificate. 

Let me know your thoughts! I'll have an update to the README on usage soon. 